### PR TITLE
Updated ToS with Dec 21 version

### DIFF
--- a/legal/terms-of-service.md
+++ b/legal/terms-of-service.md
@@ -1,119 +1,121 @@
+
 # Terms of Service
-## Date: July 1, 2018
+## Last updated: 21 December 2018. Contents:
+1 **Background:** What - How - Who. <br>
+2 **Privacy:** Collection - Retention - Identifiers - Permissions. <br>
+3 **Obligations:** Take responsibility - Act prudently - Play nicely - Respect others' work. <br>
+4 **Constraints:** No guarantees - Moving parts - Blockchain interaction. <br>
+5 **Interpretation:** Enforcing selectively - Dispute resolution - Nailing down our agreement - Third parties. <br>
 
-1.&nbsp;&nbsp; BASICS <br>
-2.&nbsp;&nbsp; OBLIGATIONS<br>
-3.&nbsp;&nbsp; CONSTRAINTS<br>
-4.&nbsp;&nbsp; DATA COLLECTION<br>
-5.&nbsp;&nbsp; INTERPRETATION<br>
+## **1. Background**
+(1.1 What - 1.2 How - 1.3 Who)
 
-## 1. BASICS
-1.1. Parties: You are at least 18 years old, and at least the age of majority where you reside. We are Decentral, Inc. (decentral.ca), a Canadian corporation which conducts business from premises at 292 Adelaide St. W., Suite 401, Toronto ON, M5V 1P6. This is a legal agreement between you and Decentral.
+**1.1. What:** Jaxx Liberty is non-custodial blockchain software for people. Its tools help users interact with third-party blockchain coins, tokens, and cryptocurrencies (together, *"digital assets"*), and organize information about them. 
 
-1.2. Service: Decentral makes and maintains software called Jaxx. Jaxx informs users about virtual currencies, cryptocurrencies, and blockchain tokens (together, "Digital Assets") through third-party information, and enables users to access and transfer Digital Assets recorded on third-party blockchains. 
+Software should help protect human rights, like privacy. Jaxx Liberty is designed to respect your privacy. We avoid collecting personal information. We have no access to your 12-word [mnemonic phrase](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) or the private keys derived from it. That means we can't help recover them if lost, so install your mnemonic phrase on a second device. At the very least, write it down.
 
-Software should help protect human rights, like privacy. Jaxx is designed to respect your privacy. We don't have access to your Backup Phrase or private keys: if you lose them, we can't help recover them. Install them on a second device or, at the very least, write them down.
+**1.2. How:** You can use Jaxx Liberty software, services, and support at no charge, as long as you abide by these terms. You're free to terminate the agreement by stopping to use Jaxx Liberty; we're free to stop providing it.
 
-1.3. Agreement: This agreement lets you use Jaxx software, services, and support at no charge, as long as you respect certain obligations, understand certain constraints, and are comfortable with certain data practices. You're free to terminate the agreement by stopping to use Jaxx. We're free to stop providing any aspect of it.
+Our agreement doesn't apply to third-party information, including the news headlines Jaxx Liberty integrates, market rates and data we include, and external services to which we help you connect. Nor does this agreement cover your relationship with the digital assets with which Jaxx Liberty lets you interact -- but which Decentral neither created nor can influence. Third parties apply their own terms and policies. Review them.
 
-This agreement doesn't apply to third-party information, like the evolving set of RSS feeds integrated into Jaxx. Nor does this agreement apply to clearly-marked third-party services offered on the Jaxx platform. Nor does this agreement cover your relationship with the Digital Assets with which Jaxx lets you interact, but which Decentral neither created nor can influence. Where third parties apply their own terms and policies, it's worth reviewing them.
+**1.3. Who:** We're Decentral Inc. (decentral.ca), a Canadian corporation (info@jaxx.io; P.O. Box P. O. Box 292, Station B, Toronto ON, M5T 2W2), which makes and maintains the Jaxx Liberty software, and can assign it only to someone who takes over the software or our company. 
 
-1.4. Updates: When we update this agreement, we'll push it to Jaxx, identify it in the release, show the change date, and archive the previous version online. Unless the change is immaterial or to your clear advantage, we'll propose it 30 days in advance, so you have time to reject the change by ceasing use. 
+You're at least 18 years old, at least the age of majority where you reside, and control or own the device running Jaxx Liberty. No Canadian or U.S. governments has embargoed, designated as "terrorist supporting", or prohibited or restricted you or the place you live. You can't assign the agreement to anyone. 
 
-## 2. OBLIGATIONS
-2.1. Take Responsibility:  We provide Jaxx without charge. Our ability to do that depends partly on your taking responsibility for how you use Jaxx. The following three items are therefore fundamental to our agreement:
+This agreement is between you and us: it binds no one else. The app store or other download intermediary where you obtained Jaxx Liberty does have the right to enforce this agreement's terms as a third-party beneficiary. But no download intermediary has any responsibility for Jaxx Liberty -- not its content, not its maintenance or support, not product liability or consumer law or regulatory compliance, not intellectual property infringement.
 
-First, we can't recover your Backup Phrase. We have no access to it. If you don't install the Backup Phrase on a second device, write it down, and keep it in a safe place, you may lose access to your Digital Assets forever. Don't do that. 
+## **2. Privacy**
+(2.1 Collection - 2.2 Retention - 2.3 Identifiers - 2.4 Permissions)
 
-Second, Decentral isn't liable for any losses or damages that result from providing you with Jaxx software, services, and support. Nor shall our liability to you exceed, under any circumstances, the greater of the Canadian dollar value of 0.01 bitcoins, and C$50.
+**2.1. Collection:** The best way to respect your privacy is to avoid snooping. Our pro-privacy stance requires us to avoid collecting or exposing, "personal information": anything that could identify you, whether on its own or when combined with other information. Your mnemonic phrase is stored, and your private keys derived, on your device only. We can't access them. You can always take them elsewhere. You're never locked into Jaxx Liberty. 
 
-Third, you indemnify Decentral against any claims, damages, losses, and legal fees incurred due to your use of Jaxx, including support services. If someone sues us about what you do, you pay.
+Jaxx Liberty does build in pseudonymous identifiers. Decentral is exposed to limited personal information from Jaxx Liberty users. But we: avoid retaining personal information we're exposed to; minimize the identifiers we have to generate; and will provide and erase any holdings on request: legal@jaxx.io.  We bind our staff and seek to bind [every relevant contractor](https://jaxx.io/thirdparties-current.html) to confidentiality agreements. We use only encrypted connections between our own servers, and insist on them with third-party servers. 
 
-You can't assign this agreement to someone else. If they install Jaxx, they enter into their own agreement with us. 
+**2.2. Minimizing what we retain:** Using the Internet means [leaking personal information](https://panopticlick.eff.org/). When your Jaxx Liberty establishes an encrypted connection to our [AWS-hosted](https://aws.amazon.com/privacy/) virtual servers, your Internet Protocol address, device type,  operating system language, and monthly-regenerated Client Pseudonym are logged. 
 
-2.2. Act Prudently:  Decentral doesn't create, and has no control over, any of the Digital Assets you interact with through Jaxx. You, alone, are responsible for the Digital Assets you choose and use. It's therefore up to you to act prudently by doing at least four things.
+We parse each log, increment relevant non-personal statistics counters -- some linked with Client Pseudonym -- and delete the log itself within 24 hours. But there are three circumstances where we're required to go beyond that:
+
+ - We're not able to offer Jaxx Liberty in every region, so we first check whether your IP address is associated with somewhere we can't offer service. It's an inexact science.
  
-a) You can't act prudently if you haven't learned the basics about the Digital Assets you're considering interacting with. Carefully review the list of supported Digital Assets before engaging in any transactions. Search for them online. Vet them carefully. 
+ - We're not allowed to relay transactions if they include blockchain addresses designated by lawful authorities, so we check each transaction against mandated blocklists.
  
-b) Jaxx doesn't require you to register or log in, but does ask you to enter a "Backup Phrase", or create a new one, to generate the private and public keys needed to make transactions. Your Backup Phrase, private keys, and passwords (collectively, "Private Key Information") is only stored locally, on your device. Losing Private Key Information is therefore no harder than dropping your phone in a lake, experiencing a bad software update, or other events typical of modern digital life. Back it up or, even better, install Jaxx on another device with the same Backup Phrase, and make sure it works, or you could lose access to your Digital Assets forever.
+ - We may have been legally compelled to preserve the log. Where we can, we'll say when.
+
+We don't provide the limited personal information we do have to anyone unless legally compelled and, to the extent  we're allowed and it's possible, we notify the affected parties. 
+
+**2.3. Decoupled identifiers:** Jaxx Liberty has no accounts, because your mnemonic phrase and private keys are none of our business. But Jaxx Liberty does *(i)* generate a temporary Client Pseudonym for pseudonymous metrics collection; *(ii)* provide user support; and *(iii)* derive a persistent "Unity" blockchain address from your mnemonic, and allow you to pair it with an optional "MyJaxx" display name and email address.
+
+- Client Pseudonym, a temporary identifier regenerated regularly with no carry-over, is used for security and metrics. For security, back-end access is limited to checksum-matching Client Pseudonyms. For metrics, a Client Pseudonym is matched with limited data points to develop unique-user aggregates across a period, then discarded.
+
+- User support is run separately from the Jaxx Liberty systems, therefore decoupled from Client Pseudonym, Unity address, and display name or email address. Providing personal information within user support -- like an email address -- exposes it to a [third party bound contractually to respect your privacy](https://jaxx.io/thirdparties-current.html). If you reach out to our support teams on uncontracted social media platforms, they may respond on the same platform -- to which you will therefore have exposed the information you've chosen to disclose.
+
+- Unity address, a persistent pseudonym, is decoupled from your Internet Protocol address, blockchain activity, and device information. We can't deduce your mnemonic phrase from it, don't have information about whose it is, and don't expose it outside our systems -- but hope to use it down the road for in-app gamification.
+
+- Your display name and email address -- if you opt in -- gives us a way to provide you with updates and interact with your display name. You can always withdraw consent for email subscriptions by clicking on the link at the bottom of the email.
+
+**2.4. App permissions:**  Jaxx Liberty's mobile editions seek camera permissions. This is to read a QR code, and store it on-device, in order to pair another Jaxx Liberty instance or scan a blockchain address. Jaxx Liberty uses those permissions carefully: it uses the camera only for those purposes and only at your prompting, and never sends anything off-device.
+
+## **3. Obligations**
+
+(3.1 Take responsibility - 3.2 Act prudently - 3.3 Play nicely - 3.4 Respect others' work)
+
+**3.1. Take responsibility:**  We can provide Jaxx Liberty because you take responsibility for what you do with it. So the following are fundamental to our agreement:
+
+a) We can't recover your mnemonic phrase. We have no access to it. If you don't install it on a second device, or keep a physical copy in a safe place, you may lose access to your digital assets forever. Don't do that. 
+
+b) Decentral isn't liable for any loss or damage that result from providing you with Jaxx Liberty software, services, and support. Nor shall our liability to you exceed, under any circumstances, the greater of the Canadian dollar value of 0.01 bitcoins, and C$50.
+
+c) You indemnify Decentral against any claims, damages, losses, and legal fees incurred due to your use of Jaxx Liberty, including support services. If someone sues us about what you do, you pay.
+
+**3.2. Act prudently:**  Decentral doesn't create, and has no control over, digital assets you interact with through Jaxx Liberty -- so it's up to you to interact with them prudently by doing these three things.
  
-c) Secure your devices and your backups. If someone steals your Backup Phrase or accesses your devices, they could control your Digital Assets. Networks, devices, and software environments are rife with viruses and malware. Carefully guard your Private Key Information; take the time to update and secure your devices; use sites (like Security Planner) to learn about improving your online safety.
+a) Learn the basics about digital assets you're considering interacting with. Search for them online. Vet them carefully. Find someone who knows more; ask them.
  
-d) Even if you delete Jaxx software from a device, data may remain behind. On a shared device like a public computer, this could allow someone to access your transactions without authorization. Take care where you install Jaxx, and extra care to eradicate every trace when you delete it.
-
-2.3. Play Nicely: Decentral has a strong commitment to user autonomy. But there are some things either Jaxx isn't designed to support, or Decentral isn't allowed to. You agree not to:
-
-a) use Jaxx in a way likely to interfere with other Jaxx users or servers, such as excessive API calls or network spam; or
-
-b) use Jaxx in a manner contrary to the laws of Canada or your local laws.
-
-Ensure your transactions with a Digital Asset conform to its rules, especially with smart contract systems.
-
-2.4. Respect Others' Work: Jaxx is made up of intellectual property. That includes intellectual property held by Decentral, like copyright in Jaxx's code; copyright in our text, images, and sounds; and trademarks in the distinctive words, symbols, and designs that identify Decentral and Jaxx. 
+b) Your mnemonic phrase, private keys, and passwords live only on-device. Losing them is no harder than dropping your phone in a lake, experiencing a bad software update, or other events of modern digital life -- and networks, devices, and software environments are rife with viruses and malware. Back up to a safe, private place, or install on another device. Secure them. [Learn about](https://securityplanner.org) improving your online safety.
  
-We licence Jaxx to you, royalty-free, on a non-exclusive, worldwide, but personal and non-transferable basis. We don't licence the right to re-distribute Jaxx, modify its code, or use its content or Decentral's trademarks in other software or projects. Those require Decentral's written permission first. 
+c) Even if you delete Jaxx Liberty software from a device, data may remain behind -- like on a shared device or public computer. Take care where you install Jaxx Liberty, and extra care to eradicate every trace when you delete it.
+
+**3.3. Play nicely:** Decentral has a strong commitment to user autonomy. But there are some things either Jaxx isn't designed to support, or Decentral isn't allowed to. You agree not to:
+
+a) use Jaxx Liberty in a way likely to interfere with other users or servers, such as excessive API calls, network spam, or rewards faucets; or
+
+b) use Jaxx Liberty in a manner contrary to laws -- of Canada, and where you live.
+
+Do ensure your transactions with a digital asset conform to its rules, especially with smart contract systems.
+
+**3.4. Respect others' work:** Jaxx Liberty is made up of intellectual property held by Decentral, like copyright in Jaxx Liberty's code and in our text, images, and sounds; and trademarks in the distinctive words, symbols, and designs that identify Decentral and Jaxx. 
  
-You may, yourself, choose to provide feedback on Jaxx. We'll assume you've allowed us to use and keep your feedback, incorporate it, and hold a non-exclusive perpetual licence in it without royalty or obligation.
+We licence Jaxx Liberty to you, royalty-free, on a non-exclusive, worldwide, but personal and non-transferable basis. We don't licence the right to re-distribute Jaxx Liberty, modify its code, or use its content or Decentral's trademarks in other software or projects. Those require Decentral's written permission first. 
  
-Third parties provide information, software libraries, and services that Jaxx uses or is partly built on. We assert no copyright in the RSS feeds we pass through. We do not own third-party software libraries. We make use of third-party platforms. Please refer to and respect relevant third-party licenses.
-
-## 3. CONSTRAINTS
-3.1. No Guarantees: Jaxx software, services, and support are provided at no cost, as is and, to the greatest extent laws allow, without any warranty at all. Please therefore note that we don't warrant Jaxx is of merchantable quality or fit for your purpose, even if you've notified us of the purpose. Nor can we warrant that Jaxx is bug-free. Bugs are inevitable. We work hard to rank and squash them.
-
-3.2. Moving Parts: Using software to interact with Digital Assets is risky. It depends on a complex chain of moving parts working together, and working properly. 
+You may, yourself, choose to give us feedback. We'll assume you've allowed us to use and keep your feedback, incorporate it, and hold a non-exclusive perpetual licence in it without royalty or obligation.
  
-We've described basic steps we expect you to take to act prudently, and set out the extent of our liability and of your indemnity to us. For the same reasons, we can't be liable to you for, and disclaim the risks involved in, these moving parts. They include:
- 
-* failures in your connectivity, hardware, other software, and operating system (mobile or desktop), and how these interact with each other and with Jaxx; cloud backup software that may upload your private files or information to third-party services, although we try to disable this functionality's ability to store your Backup Phrase or private keys in the cloud; malware, viruses or other malicious software that is able to take control of or interfere with your Jaxx instance; communication delays between your Jaxx instance and a node or relay service for a Digital Asset;
-* version updates that are incompatible or don't work properly on your device; and
-* theft of Digital Assets.
+Third parties provide information, software libraries, and services that Jaxx Liberty uses or is partly built on. We assert no copyright in the RSS feeds we pass through, market data we parse, or third-party software libraries. Please refer to and respect relevant third-party licenses.
 
-The same disclaimer of liability and risk applies to any damages or issues arising from our free technical support service. It is provided on a best-efforts basis. You get what you pay for.
+## **4. Constraints**
+(4.1 No guarantees - 4.2 Moving parts - 4.3 Blockchain interaction)
 
-3.3. Blockchain Interaction: Jaxx provides functions for sending Digital Assets' transfer instructions. Jaxx doesn't control the blockchains to which the instructions are sent. That puts some constraints on what we're able to do or be responsible for.
+**4.1. No guarantees:** Jaxx Liberty software, services, and support are provided at no cost, as is and, to the greatest extent laws allow, without any warranty at all. We don't warrant Jaxx Liberty is of merchantable quality or fit for your purpose, even if you've notified us of the purpose. Nor can we warrant that Jaxx Liberty is bug-free: bugs are inevitable. We work hard to rank and squash them.
 
-The only authentic record of Digital Assets transactions is the applicable blockchain. We can't guarantee that the transfer instructions will be acted on and your transactions stored on a blockchain, nor that once stored, they remain on the blockchain. 
+**4.2. Moving parts:** Using software to interact with digital assets is risky. It depends on a complex chain of moving parts working together, and working properly. 
 
-Many Digital Asset systems require transaction fees, like mining fees. If the transaction fees are set too low or too high, you may incur losses. We can't be responsible for them.
+For instance, your connectivity, hardware, cloud or local software, or operating system (mobile or desktop) may fail or prove incompatible with each other, or with a version of Jaxx Liberty. Your backup software may upload your private files or information to third-party services. Malware, viruses, or other malicious software on your device may interfere with your Jaxx Liberty install. Communication delays may creep in between your Jaxx Liberty and a node or relay service for a digital asset. 
 
-Jaxx's market information about Digital Assets reflects a point in time for underlying data fluctuating constantly. The sending and execution of transfer instructions necessarily involves a longer period than that point in time, and the data values reflected in your transactions will differ accordingly. We're not responsible for that difference.
+We've described basic steps we expect you to take to act prudently, and set out the extent of our liability and your indemnity to us. For the same reasons, we can't be liable to you for, and disclaim the risks involved in, moving parts like those listed here. It's provided on a best-efforts basis. You get what you pay for.
 
-## 4. DATA POLICY
-4.1. Personal Information Processing: "Personal information" includes anything about you or that could be used to identify you, either on its own or in combination with other information. Consistent with our pro-privacy approach, we avoid collecting personal information. Your public and private key information is stored locally on your device and maintained through your Backup Phrase. Only the person in control of the device with your Jaxx instance and of your Backup Phrase backup has access to these, so you have everything you need to port your activity to other applications. 
- 
-Personal information we do hold is treated as confidential. We bind all of our staff and seek to bind every relevant contractor, who we've identified, to confidentiality agreements. We use only encrypted connections between our own servers, and insist on them with third-party servers. 
- 
-We do not provide personal information to anyone else unless legally compelled to and, to the extent legally permitted, provide notice of having done so to the affected parties. 
+**4.3. Blockchain interaction:** Jaxx Liberty provides functions for sending digital assets' transfer instructions. Jaxx Liberty doesn't control the blockchains to which the instructions are sent: the only authentic transaction record is the blockchain.
 
-4.2. Necessary Identifiers: In order to maintain your settings across the Jaxx instances installed on different devices, Jaxx indirectly derives a unique Jaxx ID from your Backup Phrase. The Jaxx ID is derived from the Backup Phrase using a one-way cryptographic hash function, so we can't feasibly use your Jaxx ID to reverse-engineer your Backup Phrase. 
- 
-Because your Jaxx ID is a persistent identifier, it is in the nature of personal information. However, we do not require information to be tied to it beyond your app settings, like the wallets to display and sequence to show them in. We do not expose the Jaxx ID outside our systems. We do not even have information about whose Jaxx ID it is.
+We can't guarantee transfer instructions will be acted on and your transactions stored on a blockchain -- nor that, once stored, they remain there. Many blockchain networks require transaction fees, like mining fees, which if set too low or high may result in your incurring losses. We can't be responsible for these.
 
-4.3. Opt-In Identifiers: Although we do not require other personal information to be tied to your Jaxx ID, we do give you the opportunity to do so through myJAXX. Separately, you may choose to provide personal information to us through the support process.
- 
-The myJAXX module requests your email address in order to provide you with updates and let you port your myJAXX settings. It also asks you to choose a display name. After that, myJAXX defaults to the display name and email address you have already tied to your Jaxx ID.
- 
-The support process is not tied to your Jaxx ID, but user communications generated through the support process may include personal identifiers, and are exposed to a contracted third-party. Further, when you reach out to our support teams on uncontracted social media platforms, they may respond on the same platform, to which you will therefore have exposed the information you've chosen to disclose.
- 
-We delete email address and, once the limitation period has run in your jurisdiction, customer support information on request (legal@jaxx.io). You can always withdraw consent for email subscriptions by clicking on the link at the bottom of the email. 
+Jaxx Liberty's market information reflects a point in time for underlying data fluctuating constantly. Sending transfer instructions involves a longer period: the data values reflected in your transactions will differ accordingly. We're not responsible for that difference.
 
-4.4. Personal Information Holdings: In addition to necessary (Jaxx ID) and opt-in (myJAXX, customer support) identifiers, we have access to: 
+## **5. Interpretation**
+(5.1 Enforcing selectively - 5.2 Dispute resolution - 5.3 Nailing down our agreement)
 
-a) your transaction addresses and, occasionally, public keys, and the blockchain transactions you make using them, which may be relayed through servers ("nodes"); 
+**5.1. Enforcing selectively:** Failing to assert a right under this agreement doesn't waive the right to assert another right, or the same right, next time.
 
-b) phone logs, Web logs, and third-party cookies.
- 
-Transaction information is publicly visible due to the very nature of distributed ledger systems. We delete phone and Web logs on a rolling basis. 
+**5.2. Dispute resolution:** Other than conflicts of law principles, this agreement is governed by the laws applicable in Toronto, Ontario, Canada, to whose courts we both agree to submit disputes we haven't been able to resolve bet
+ween us. The Convention for the International Sale of Goods doesn't apply.
 
-Decentral does retain some aggregated, anonymized Jaxx usage information in order to improve its functionality and user interface. This information is not stored at the individual user level or in conjunction with any device-specific or persistent identifier.
+**5.3. Nailing down our agreement**: This is the whole agreement between you and Decentral. We'll push any updates to Jaxx Liberty, identify them in release notes, show the change date, and archive the previous version online. Unless the change is immaterial or to your clear advantage, we'll propose it 30 days in advance, so you have time to reject the change by ceasing use. 
 
-4.5. App Permissions: The Jaxx mobile app seeks camera permissions. These permissions are used only to read a QR code and store it on-device, to pair another Jaxx instance; and only at your prompting. Jaxx does not receive any other camera input and does not otherwise access your camera.                                                                     
-
-## 5. INTERPRETATION
-5.1. Enforcing Selectively: Failing to assert a right under this agreement doesn't waive the right to assert another right, or the same right next time.
-
-5.2. Going to Court: Other than conflicts of law principles, this agreement is governed by the laws applicable in Toronto, Ontario, Canada, to whose courts the parties attorn. The Convention for the International Sale of Goods doesn't apply.
-
-5.3. Nailing Down our Agreement: This is the whole agreement between you and Decentral. It supersedes any other agreement, representations, or understandings, however communicated, and can be amended only if both parties agree, in writing, with copy to legal@decentral.ca. Where we provide this agreement in more than one language and they don't precisely agree, the English-language version takes precedent. Les parties aux présentes conviennent que cette entente soit rédigée en anglais. 
-
-5.4. Restructuring our Business: Decentral may assign this agreement upon 15 days' notice.
+This agreement supersedes any other agreement or representation, however communicated, and can be amended only if both parties agree, in writing, with copy to legal@decentral.ca. Where we provide this agreement in more than one language and they don't precisely agree, the English-language version takes precedent. Les parties aux présentes conviennent que cette entente soit rédigée en anglais.


### PR DESCRIPTION
This replaces the July 1st, 2018 ToS with the new one that was published with Jaxx 2.1.1 on December 21, 2018